### PR TITLE
relayer: method to check that write tx confirmed

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,21 @@ Example:
 Tests:
 ======
 
-Running the tests requires a local regtest node.
+Running the tests requires a local regtest node:
 
 	bitcoind -chain=regtest -rpcport=18332 -rpcuser=rpcuser -rpcpassword=rpcpass -fallbackfee=0.000001 -txindex=1
+
+Setup wallet, generate coins:
 
 	bitcoin-cli -regtest -rpcport=18332 -rpcuser=rpcuser -rpcpassword=rpcpass createwallet w1
 
 	export COINBASE=$(bitcoin-cli -regtest -rpcport=18332 -rpcuser=rpcuser -rpcpassword=rpcpass getnewaddress)
 
 	bitcoin-cli -regtest -rpcport=18332 -rpcuser=rpcuser -rpcpassword=rpcpass generatetoaddress 101 $COINBASE
+
+Run a background miner:
+
+	watch -n 5 bitcoin-cli -regtest -rpcport=18332 -rpcuser=rpcuser -rpcpassword=rpcpass generatetoaddress 1 $COINBASE
 
 Idle for a while till coinbase coins mature.
 

--- a/relayer.go
+++ b/relayer.go
@@ -253,8 +253,8 @@ func NewRelayer(config Config) (*Relayer, error) {
 	}, nil
 }
 
-func (r Relayer) Read(height uint64) ([][]byte, error) {
-	hash, err := r.client.GetBlockHash(int64(height))
+func (r Relayer) Read(height int64) ([][]byte, error) {
+	hash, err := r.client.GetBlockHash(height)
 	if err != nil {
 		return nil, err
 	}
@@ -274,6 +274,22 @@ func (r Relayer) Read(height uint64) ([][]byte, error) {
 		}
 	}
 	return data, nil
+}
+
+func (r Relayer) Check(hash *chainhash.Hash) (int64, error) {
+	tx, err := r.client.GetRawTransactionVerbose(hash)
+	if err != nil {
+		return 0, err
+	}
+	hash, err = chainhash.NewHashFromStr(tx.BlockHash)
+	if err != nil {
+		return 0, err
+	}
+	block, err := r.client.GetBlockVerbose(hash)
+	if err != nil {
+		return 0, err
+	}
+	return block.Height, nil
 }
 
 func (r Relayer) Write(data []byte) (*chainhash.Hash, error) {

--- a/relayer_test.go
+++ b/relayer_test.go
@@ -3,9 +3,63 @@ package bitcoinda_test
 import (
 	"encoding/hex"
 	"fmt"
+	"time"
 
 	bitcoinda "github.com/rollkit/bitcoin-da"
 )
+
+// NOTE: tests need a local regtest node running like so:
+// bitcoind -chain=regtest -rpcport=18332 -rpcuser=rpcuser -rpcpassword=rpcpass -fallbackfee=0.000001 -txindex=1
+
+// ExampleRelayer_Read tests that reading data from the blockchain works as
+// expected.
+// NOTE: needs a background miner to keep generating regtest blocks
+// I like to keep this running in the background:
+// export COINBASE=$(bitcoin-cli -regtest -rpcport=18332 -rpcuser=rpcuser -rpcpassword=rpcpass getnewaddress)
+// watch -n 5 bitcoin-cli -regtest -rpcport=18332 -rpcuser=rpcuser -rpcpassword=rpcpass generatetoaddress 1 $COINBASE
+func ExampleRelayer_Read() {
+	// Example usage
+	relayer, err := bitcoinda.NewRelayer(bitcoinda.Config{
+		Host:         "localhost:18332",
+		User:         "rpcuser",
+		Pass:         "rpcpass",
+		HTTPPostMode: true,
+		DisableTLS:   true,
+	})
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	hash, err := relayer.Write([]byte("rollkit-btc: gm"))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	time.Sleep(5 * time.Second)
+	var height int64
+	for i := 0; i < 10; i++ {
+		height, err = relayer.Check(hash)
+		if err != nil {
+			fmt.Printf("%v: retrying in 1s\n", err)
+			time.Sleep(time.Second)
+			continue
+		}
+	}
+	blobs, err := relayer.Read(height)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	for _, blob := range blobs {
+		got, err := hex.DecodeString(fmt.Sprintf("%x", blob))
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		fmt.Println(string(got))
+	}
+	// Output: rollkit-btc: gm
+}
 
 // ExampleRelayer_Write tests that writing data to the blockchain works as
 // expected.
@@ -31,43 +85,4 @@ func ExampleRelayer_Write() {
 	fmt.Println("done")
 	// Output: Writing...
 	// done
-}
-
-// ExampleRelayer_Read tests that reading data from the blockchain works as
-// expected.
-func ExampleRelayer_Read() {
-	// Example usage
-	relayer, err := bitcoinda.NewRelayer(bitcoinda.Config{
-		Host:         "localhost:18332",
-		User:         "rpcuser",
-		Pass:         "rpcpass",
-		HTTPPostMode: true,
-		DisableTLS:   true,
-	})
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-	_, err = relayer.Write([]byte("rollkit-btc: gm"))
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-	// TODO: either mock or generate block
-	// We're assuming the prev tx was mined at height 146
-	height := uint64(146)
-	blobs, err := relayer.Read(height)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-	for _, blob := range blobs {
-		got, err := hex.DecodeString(fmt.Sprintf("%x", blob))
-		if err != nil {
-			fmt.Println(err)
-			return
-		}
-		fmt.Println(string(got))
-	}
-	// Output: rollkit-btc: gm
 }


### PR DESCRIPTION
This PR adds a new method `relayer.Check` which takes a write transaction hash and returns the height at which the transaction was included in a block.

This is useful because we want to be able to pass the block height to `Read` and this fixes a hack which was in place in the tests.