### PR TITLE
rename: rollkit-btc -> bitcoin-da

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-rollkit-btc:
-============
+bitcoin-da:
+===========
 
 
 This package provides a reader / writer interface to bitcoin.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rollkit/rollkit-btc
+module github.com/rollkit/bitcoin-da
 
 go 1.19
 

--- a/relayer.go
+++ b/relayer.go
@@ -1,4 +1,4 @@
-package rollkitbtc
+package bitcoinda
 
 import (
 	"bytes"

--- a/relayer_test.go
+++ b/relayer_test.go
@@ -1,17 +1,17 @@
-package rollkitbtc_test
+package bitcoinda_test
 
 import (
 	"encoding/hex"
 	"fmt"
 
-	rollkitbtc "github.com/rollkit/rollkit-btc"
+	bitcoinda "github.com/rollkit/bitcoin-da"
 )
 
 // ExampleRelayer_Write tests that writing data to the blockchain works as
 // expected.
 func ExampleRelayer_Write() {
 	// Example usage
-	relayer, err := rollkitbtc.NewRelayer(rollkitbtc.Config{
+	relayer, err := bitcoinda.NewRelayer(bitcoinda.Config{
 		Host:         "localhost:18332",
 		User:         "rpcuser",
 		Pass:         "rpcpass",
@@ -37,7 +37,7 @@ func ExampleRelayer_Write() {
 // expected.
 func ExampleRelayer_Read() {
 	// Example usage
-	relayer, err := rollkitbtc.NewRelayer(rollkitbtc.Config{
+	relayer, err := bitcoinda.NewRelayer(bitcoinda.Config{
 		Host:         "localhost:18332",
 		User:         "rpcuser",
 		Pass:         "rpcpass",


### PR DESCRIPTION
This PR renames the package to `bitcoin-da` to reflect it's purpose and it's generic interface better.